### PR TITLE
Adding initial set of workflow examples

### DIFF
--- a/Examples from James/create_slack_channel.yaml
+++ b/Examples from James/create_slack_channel.yaml
@@ -1,0 +1,25 @@
+version: "1"
+name: Create Slack Channel
+enabled: true
+triggers:
+  - type: manual
+    enabled: true
+inputs:
+  - name: channel_name
+    default: test-channel
+    type: string
+consts:
+  slack_token: xoxb-xxxxxxxxxxxxxxxx
+steps:
+  - name: create-slack-channel
+    type: http
+    with:
+      url: https://slack.com/api/conversations.create
+      method: POST
+      headers:
+        Content-Type: application/json; charset=utf-8
+        Authorization: Bearer {{ consts.slack_token }}
+      body:
+        name: "{{ inputs.channel_name }}"
+        is_private: false
+      timeout: 30s

--- a/Examples from James/inspect_splunk_fields.yaml
+++ b/Examples from James/inspect_splunk_fields.yaml
@@ -1,0 +1,39 @@
+version: "1"
+name: Inspect Splunk Fields
+enabled: true
+triggers:
+  - type: manual
+    enabled: true
+inputs:
+  - name: index_name
+    default: omm-ep1
+    type: string
+consts:
+  splunk_url: https://splunkurl.com:8089
+  splunk_auth: Basic xxxxxxxxxx
+steps:
+  - name: check_field_list
+    type: http
+    with:
+      url: "{{consts.splunk_url}}/services/search/jobs"
+      method: POST
+      headers:
+        Content-Type: application/x-www-form-urlencoded
+        Authorization: "{{consts.splunk_auth}}"
+      body: "search={{ ('search index=' ~ inputs.index_name ~ ' | fieldsummary maxvals=0 | table field count') | urlencode }}&count=0&output_mode=json"
+      timeout: 30s
+  - name: wait_for_search
+    type: wait
+    with:
+      duration: 2s
+  - name: get-splunk-results
+    type: http
+    with:
+      url: "{{consts.splunk_url}}/services/search/jobs/{{steps.check_field_list.output.data.sid}}/results?output_mode=json&count=0"
+      method: GET
+      headers:
+        Authorization: "{{consts.splunk_auth}}"
+      timeout: 30s  
+
+
+      

--- a/Examples from James/list_splunk_indices.yaml
+++ b/Examples from James/list_splunk_indices.yaml
@@ -1,0 +1,34 @@
+version: "1"
+name: List Splunk Indices
+enabled: true
+triggers:
+  - type: manual
+    enabled: true
+consts:
+  splunk_url: https://splunkurl.com:8089
+  splunk_auth: Basic xxxxxxxxx
+steps:
+  - name: list_splunk_indices
+    type: http
+    with:
+      url: "{{consts.splunk_url}}/services/search/jobs"
+      method: POST
+      headers:
+        Content-Type: application/x-www-form-urlencoded
+        Authorization: "{{consts.splunk_auth}}"
+      body: "search=%7Crest%20%2Fservices%2Fdata%2Findexes%20count%3D0%20datatype%3Dall%20%7C%20search%20totalEventCount%20%3E%200%20title%20!%3D%20_*%20%7C%20table%20title%20totalEventCount&count=0&output_mode=json"
+      timeout: 30s
+  - name: wait_for_search
+    type: wait
+    with:
+      duration: 5s
+  - name: get_splunk_results
+    type: http
+    with:
+      url: "{{consts.splunk_url}}/services/search/jobs/{{steps.list_splunk_indices.output.data.sid}}/results?output_mode=json&count=0"
+      method: GET
+      headers:
+        Authorization: "{{consts.splunk_auth}}"
+      timeout: 30s 
+
+      

--- a/Examples from James/lookup_hash_on_vt.yaml
+++ b/Examples from James/lookup_hash_on_vt.yaml
@@ -1,0 +1,22 @@
+version: "1"
+name: Send Hash to Virustotal
+enabled: true
+triggers:
+  - type: manual
+    enabled: true
+inputs:
+  - name: vt_hash
+    default: ff808d0a12676bfac88fd26f955154f8884f2bb7c534b9936510fd6296c543e8
+    type: string
+consts:
+  vtkey: xxxxxxxxxxxxx
+steps:
+  - name: hash-lookup-vt
+    type: http
+    with:
+      url: https://www.virustotal.com/api/v3/search?query={{inputs.vt_hash}}
+      method: GET
+      headers:
+        Content-Type: application/json
+        x-apikey: "{{ consts.vtkey }}"
+      timeout: 30s

--- a/Examples from James/post_to_slack_message_with_blocks.yaml
+++ b/Examples from James/post_to_slack_message_with_blocks.yaml
@@ -1,0 +1,32 @@
+version: "1"
+name: Post to Slack Channel with blocks format
+enabled: true
+triggers:
+  - type: manual
+    enabled: true
+inputs:
+  - name: channel_id
+    default: "xxxxxxxxxx"
+    type: string
+  - name: blocks_json
+    type: string
+    default: "{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*This is a Cool test message!* :wave:\\nHere’s a richer Slack block test with multiple sections.\"},\"fields\":[{\"type\":\"mrkdwn\",\"text\":\"*Status:*\\nRunning\"},{\"type\":\"mrkdwn\",\"text\":\"*Priority:*\\nHigh\"}]},{\"type\":\"context\",\"elements\":[{\"type\":\"mrkdwn\",\"text\":\"Updated: <!date^1672531200^{date_num} {time_secs}|fallback>\"},{\"type\":\"image\",\"image_url\":\"https://api.slack.com/img/blocks/bkb_template_images/profile_1.png\",\"alt_text\":\"profile\"}]},{\"type\":\"actions\",\"elements\":[{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\"View Details\"},\"style\":\"primary\",\"url\":\"https://example.com/details\"},{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\"Dismiss\"},\"style\":\"danger\",\"value\":\"dismiss\"}]}"
+  - name: fallback_text
+    type: string
+    default: "1234"
+consts:
+  slack_token: xoxb-xxxxxxxxxxx
+steps:
+  - name: post_slack_message_rich_dynamic
+    type: http
+    with:
+      url: https://slack.com/api/chat.postMessage
+      method: POST
+      headers:
+        Content-Type: application/json; charset=utf-8
+        Authorization: "Bearer {{ consts.slack_token }}"
+      body:
+        channel: "{{ inputs.channel_id }}"
+        text: "{{ inputs.fallback_text }}"
+        blocks: "[{{ inputs.blocks_json | safe }}]"
+      timeout: 30s

--- a/Examples from James/search_splunk.yaml
+++ b/Examples from James/search_splunk.yaml
@@ -1,0 +1,39 @@
+version: "1"
+name: Search Splunk
+enabled: true
+triggers:
+  - type: manual
+    enabled: true
+inputs:
+  - name: splunk_query
+    default: source="ep1data.json" host="SRVWIN01" index="omm-ep1" sourcetype="OMM"
+    type: string
+consts:
+  splunk_url: https://splunkurl.com:8089
+  splunk_auth: Basic xxxxxxxxxx
+steps:
+  - name: send_search_to_splunk
+    type: http
+    with:
+      url: "{{consts.splunk_url}}/services/search/jobs"
+      method: POST
+      headers:
+        Content-Type: application/x-www-form-urlencoded
+        Authorization: "{{consts.splunk_auth}}"
+      body: "search={{ ('search ' ~ inputs.splunk_query) | urlencode }}&count=0&output_mode=json"
+      timeout: 30s
+  - name: wait_for_search
+    type: wait
+    with:
+      duration: 20s
+  - name: get_splunk_results
+    type: http
+    with:
+      url: "{{consts.splunk_url}}/services/search/jobs/{{steps.send_search_to_splunk.output.data.sid}}/results?output_mode=json&count=0"
+      method: GET
+      headers:
+        Authorization: "{{consts.splunk_auth}}"
+      timeout: 30s  
+
+
+      

--- a/Examples from James/send_email_via_kibana_connector.yaml
+++ b/Examples from James/send_email_via_kibana_connector.yaml
@@ -1,0 +1,38 @@
+version: "1"
+name: Send email
+enabled: true
+triggers:
+  - type: manual
+    enabled: true
+inputs:
+  - name: email_to
+    default: some.email@email.com
+    type: string
+  - name: email_subject
+    default: hello
+    type: string
+  - name: email_body
+    default: hello
+    type: string
+consts:
+  kibanaurl: http://localhost:5601
+  kibanaauth: Basic xxxxxxxx
+  kibanaemailconnector: 1234-5678-abc123-mnop
+steps:
+  - name: send-email
+    type: http
+    with:
+      url: "{{consts.kibanaurl}}/api/actions/connector/{{consts.kibanaemailconnector}}/_execute"
+      method: POST
+      headers:
+        Content-Type: application/json
+        Authorization: "{{ consts.kibanaauth }}"
+        kbn-xsrf: kibana
+      body:
+        params:
+          message: "{{inputs.email_body}}"
+          to: - 
+            "{{inputs.email_to}}"
+          subject: "{{inputs.email_subject}}"
+      timeout: 30s
+


### PR DESCRIPTION
This PR adds 7 workflow examples:

- A Workflow to lookup a specific sha256 hash on virustotal
- A set of 3 workflows to get splunk indices, inspect splunk fields and search splunk
- A workflow to send an email via a configured kibana email connector
- A workflow to create a Slack Channel
- A workflow to post a rich message to a slack channel

All have been tested individually, as well as when used within Agent Builder as a workflow tool type.

